### PR TITLE
Turn off after_build option

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -79,7 +79,6 @@ end
 activate :deploy do |deploy|
   deploy.method = :git
   deploy.branch = 'master'
-  deploy.after_build = true
 end
 
 


### PR DESCRIPTION
`middleman build`でデプロイまでしてしまうのは直感的ではないなと思ったので削除しました 
#8
