### PR TITLE
update idobata url

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -53,7 +53,7 @@ title: ginza.rb
     </div>
     <div class="sub-heading">
       <p>また、idobataで雑談してたりもします。一緒に雑談しましょう。
-      idobataルームのURLは<a href="https://idobata.io/organizations/ginzarb/rooms/ginzarb/join_request/3cddf7e0-2e26-40e9-8957-31155bf22fc2">こちら</a>
+      idobataルームのURLは<a href="https://idobata.io/#/organization/ginzarb/room/ginzarb">こちら</a>
       </p>
       <p>
       </p>


### PR DESCRIPTION
「はじめての方 / すでに参加してくれてる方」を統一するよう変更した影響で、旧 invite urlが使えなくなってしまったようなので、リンク先を新しいURLに更新しました