### PR TITLE
GITHUB_TOKEN環境変数が設定されていれば暗黙的に認証情報が渡るらしいので試してみる

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,9 +36,10 @@ jobs:
         cd build
         git add -A
         git commit -m 'Reflect changed sources'
-        git push -f https://${{ secrets.GITHUB_TOKEN }}@github.com/ginzarb/ginzarb.github.io.git master
+        git push -f origin master
       env:
         GIT_COMMITTER_NAME: willnet
         GIT_COMMITTER_EMAIL: netwillnet@gmail.com
         GIT_AUTHOR_NAME: willnet
         GIT_AUTHOR_EMAIL: netwillnet@gmail.com
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
[The value of the GITHUB_TOKEN environment variable is being used for authentication. · Issue #2922 · cli/cli](https://github.com/cli/cli/issues/2922#issuecomment-775027762)

↑はあくまでghでgitコマンドではないのだけど…
