### PR TITLE
Add `bigdecimal` as dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@
 source 'http://rubygems.org'
 
 gem "middleman"
+gem "bigdecimal"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     backports (3.25.0)
+    bigdecimal (3.1.9)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -101,6 +102,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bigdecimal
   middleman
 
 BUNDLED WITH


### PR DESCRIPTION
* リリースされている[middleman-core](https://rubygems.org/gems/middleman-core)は`activesupport >= 6.1, < 7.1`の指定がある
* Active Support 7.0はRuby 3.4をサポートしておらず、`bigdecimal`の依存が不足しており、依存関係の解決が出来ずエラーになる
  * https://github.com/ginzarb/ginzarb.github.io/actions/runs/13300718674/job/37141544069#step:4:10
* というわけで、`bigdecimal`を依存として追加してみることにしました  