### PR TITLE
Add `mutex_m` as dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source 'http://rubygems.org'
 
 gem "middleman"
 gem "bigdecimal"
+gem "mutex_m"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
       uglifier (~> 3.0)
       webrick
     minitest (5.24.0)
+    mutex_m (0.3.0)
     padrino-helpers (0.15.3)
       i18n (>= 0.6.7, < 2)
       padrino-support (= 0.15.3)
@@ -104,6 +105,7 @@ PLATFORMS
 DEPENDENCIES
   bigdecimal
   middleman
+  mutex_m
 
 BUNDLED WITH
    2.5.11


### PR DESCRIPTION
#63 の続き。

今度はローカルでちゃんと確認したので、大丈夫のハズ…。

```
$ bundle exec middleman build          [~/src/github.com/ginzarb/ginzarb.github.io:fix_build_again]
/home/yyagi/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/concurrent-ruby-1.3.3/lib/concurrent-ruby/concurrent/concern/logging.rb:1: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
/home/yyagi/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/activesupport-7.0.8.4/lib/active_support/core_ext/benchmark.rb:3: warning: benchmark was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add benchmark to your Gemfile or gemspec to silence this warning.
/home/yyagi/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-2.2.11/lib/rack/show_exceptions.rb:3: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
/home/yyagi/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/tilt-2.0.11/lib/tilt/csv.rb:4: warning: csv was loaded from the standard library, but is not part of the default gems starting from Ruby 3.4.0.
You can add csv to your Gemfile or gemspec to silence this warning.
/home/yyagi/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/tilt-2.0.11/lib/tilt/rdoc.rb:2: warning: rdoc was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add rdoc to your Gemfile or gemspec to silence this warning.
   identical  build/css/normalize.css
   identical  build/css/style.css
   identical  build/css/font-awesome.css
   identical  build/css/overwrite.css
   identical  build/css/bootstrap.css
   identical  build/css/main.css
   identical  build/css/bootstrap-responsive.css
   identical  build/css/animate.css
   identical  build/color/default.css
   identical  build/js/vendor/google-code-prettify/prettify.css
   identical  build/css/prettyPhoto.css
   identical  build/img/prettyPhoto/light_rounded/sprite.png
   identical  build/img/prettyPhoto/default/default_thumb.png
   identical  build/img/prettyPhoto/light_rounded/btnNext.png
   identical  build/img/prettyPhoto/default/sprite.png
   identical  build/img/prettyPhoto/default/sprite_prev.png
   identical  build/img/prettyPhoto/default/sprite_x.png
   identical  build/img/prettyPhoto/light_rounded/btnPrevious.png
   identical  build/img/prettyPhoto/dark_square/contentPattern.png
   identical  build/img/prettyPhoto/dark_square/sprite.png
   identical  build/img/prettyPhoto/dark_square/btnPrevious.png
   identical  build/img/prettyPhoto/facebook/contentPatternTop.png
   identical  build/img/prettyPhoto/facebook/sprite.png
   identical  build/img/prettyPhoto/facebook/contentPatternRight.png
   identical  build/apple-touch-icon.png
   identical  build/img/prettyPhoto/dark_square/btnNext.png
   identical  build/ico/apple-touch-icon-144-precomposed.png
   identical  build/ico/apple-touch-icon-114-precomposed.png
   identical  build/ico/apple-touch-icon-72-precomposed.png
   identical  build/img/glyphicons-halflings-white.png
   identical  build/ico/apple-touch-icon-57-precomposed.png
   identical  build/img/prettyPhoto/dark_rounded/btnNext.png
   identical  build/img/prettyPhoto/dark_rounded/btnPrevious.png
   identical  build/img/prettyPhoto/dark_rounded/sprite.png
   identical  build/img/prettyPhoto/dark_rounded/contentPattern.png
   identical  build/img/prettyPhoto/facebook/contentPatternBottom.png
   identical  build/img/prettyPhoto/facebook/btnPrevious.png
   identical  build/img/prettyPhoto/facebook/contentPatternLeft.png
   identical  build/apple-touch-icon-114x114-precomposed.png
   identical  build/img/prettyPhoto/facebook/btnNext.png
   identical  build/mstile-150x150.png
   identical  build/apple-touch-icon-144x144-precomposed.png
   identical  build/favicon-16x16.png
   identical  build/apple-touch-icon-precomposed.png
   identical  build/android-chrome-192x192.png
   identical  build/img/glyphicons-halflings.png
   identical  build/apple-touch-icon-72x72-precomposed.png
   identical  build/apple-touch-icon-57x57-precomposed.png
   identical  build/android-chrome-384x384.png
   identical  build/img/prettyPhoto/light_square/sprite.png
   identical  build/img/da-hover.png
   identical  build/img/logo.png
   identical  build/favicon-32x32.png
   identical  build/img/prettyPhoto/light_square/btnPrevious.png
   identical  build/img/prettyPhoto/default/sprite_y.png
   identical  build/img/prettyPhoto/default/sprite_next.png
   identical  build/img/prettyPhoto/light_square/btnNext.png
   identical  build/img/bg/bg-1.jpg
   identical  build/img/prettyPhoto/dark_rounded/default_thumbnail.gif
   identical  build/img/prettyPhoto/dark_rounded/loader.gif
   identical  build/img/prettyPhoto/facebook/default_thumbnail.gif
   identical  build/img/prettyPhoto/facebook/loader.gif
   identical  build/img/prettyPhoto/light_square/loader.gif
   identical  build/img/prettyPhoto/dark_square/default_thumbnail.gif
   identical  build/img/prettyPhoto/dark_square/loader.gif
   identical  build/img/prettyPhoto/light_square/default_thumbnail.gif
   identical  build/img/prettyPhoto/light_rounded/default_thumbnail.gif
   identical  build/img/prettyPhoto/light_rounded/loader.gif
   identical  build/img/prettyPhoto/default/loader.gif
   identical  build/favicon.ico
   identical  build/font/fontawesome/fontawesome-webfont.woff
   identical  build/font/fontawesome/fontawesome-webfont.ttf
   identical  build/font/fontawesome/FontAwesome.otf
   identical  build/font/fontawesome/fontawesome-webfont.eot
   identical  build/js/plugins.js
   identical  build/js/vendor/jquery-1.8.0.min.js
   identical  build/js/vendor/jquery.nav.js
   identical  build/font/fontawesome/fontawesome-webfont.svg
   identical  build/js/main.js
   identical  build/js/vendor/parallax/jquery.scrollTo-1.4.2-min.js
   identical  build/js/vendor/nagging-menu.js
   identical  build/js/vendor/animate.js
   identical  build/js/vendor/parallax/jquery.localscroll-1.2.7-min.js
   identical  build/js/vendor/hover/setting.js
   identical  build/js/vendor/parallax/jquery.parallax-1.1.3.js
   identical  build/safari-pinned-tab.svg
   identical  build/js/vendor/jquery.min.js
   identical  build/js/vendor/google-code-prettify/prettify.js
   identical  build/js/vendor/hover/jquery-hover-effect.js
   identical  build/js/vendor/jquery.scrollTo.js
   identical  build/js/vendor/twitter/jquery.tweet.js
   identical  build/js/vendor/prettyPhoto/setting.js
   identical  build/js/vendor/twitter/function.js
   identical  build/js/vendor/prettyPhoto/jquery.prettyPhoto.js
   identical  build/js/vendor/modernizr-2.6.1.min.js
   identical  build/js/vendor/portfolio/setting.js
   identical  build/js/vendor/portfolio/jquery.quicksand.js
   identical  build/js/vendor/custom.js
   identical  build/js/vendor/jquery.easing.js
   identical  build/crossdomain.xml
   identical  build/browserconfig.xml
   identical  build/js/vendor/bootstrap.js
   identical  build/404.html
   identical  build/robots.txt
   identical  build/site.webmanifest
   identical  build/humans.txt
   identical  build/index.html
   identical  build/LICENSE
   identical  build/README
Project built successfully.
```